### PR TITLE
Duration cast in grpc converter

### DIFF
--- a/samples/qt/README.md
+++ b/samples/qt/README.md
@@ -53,6 +53,20 @@ To run the example from root:
 ./samples/qt/build/Desktop_Qt_6_8_1-Debug/qt
 ```
 
+### ⚠️ Qt 5 build configuration: Disable USE_QT6 option in Qt Creator
+
+If you're using Qt 5, make sure to manually disable the **USE_QT6** CMake option inside Qt Creator:
+
+1. In Qt Creator, open the **Projects** tab (🔧 wrench icon on the left).
+
+2. Select the active build kit.
+
+3. Under the **CMake** section, locate the **Key: USE_QT6** entry.
+
+4. Set its value to **OFF**.
+
+This step ensures that the project builds properly with Qt 5.
+
 ## 🧰 Building from terminal with script
 
 Instead of using **Qt Creator**, you can build the project directly from the terminal using the provided script:

--- a/src/grpc_converter.cpp
+++ b/src/grpc_converter.cpp
@@ -193,8 +193,11 @@ auto GrpcConverter::operator()(const gRPCAstarteDataTypeIndividual &value) -> As
                                               value.astarte_binary_blob().end()));
     case gRPCAstarteDataTypeIndividual::kAstarteDateTime: {
       const google::protobuf::Timestamp &timestamp = value.astarte_date_time();
-      return AstarteData(std::chrono::system_clock::time_point{
-          std::chrono::seconds{timestamp.seconds()} + std::chrono::nanoseconds{timestamp.nanos()}});
+      auto secs = std::chrono::seconds{timestamp.seconds()};
+      auto nanos = std::chrono::nanoseconds{timestamp.nanos()};
+      auto duration = std::chrono::duration_cast<std::chrono::system_clock::duration>(secs + nanos);
+      const std::chrono::system_clock::time_point timepoint(duration);
+      return AstarteData(timepoint);
     }
     case gRPCAstarteDataTypeIndividual::kAstarteDoubleArray:
       return AstarteData(std::vector<double>(value.astarte_double_array().values().begin(),
@@ -221,8 +224,11 @@ auto GrpcConverter::operator()(const gRPCAstarteDataTypeIndividual &value) -> As
     case gRPCAstarteDataTypeIndividual::kAstarteDateTimeArray: {
       std::vector<std::chrono::system_clock::time_point> timestamp_vect;
       for (const auto &timestamp : value.astarte_date_time_array().values()) {
-        timestamp_vect.emplace_back(std::chrono::seconds{timestamp.seconds()} +
-                                    std::chrono::nanoseconds{timestamp.nanos()});
+        auto secs = std::chrono::seconds{timestamp.seconds()};
+        auto nanos = std::chrono::nanoseconds{timestamp.nanos()};
+        auto duration =
+            std::chrono::duration_cast<std::chrono::system_clock::duration>(secs + nanos);
+        timestamp_vect.emplace_back(duration);
       }
       return AstarteData(timestamp_vect);
     }


### PR DESCRIPTION
Add an explicit std::chrono::duration_cast in grpc_converter.cpp to convert the summed duration to system_clock::duration, ensuring compatibility across all major compilers, including MSVC.
Add a note in the README file to guide users building the project with Qt 5 in Qt Creator.